### PR TITLE
Add support for multiple providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ docker run \
 |--------------------------------------|------------------------------------------------------|
 | [Cloudflare](https://cloudflare.com) | `cloudflare`                                         |
 
-
 # Environment Variables
 
 All providers require the following environment variable:
@@ -40,10 +39,14 @@ All providers require the following environment variable:
 
 # Contributing
 
-* Fork this repository 🍴
-* Make your changes
-* Open a pull request and ask for review
-* 🎉
+## Adding a new provider
+
+To add a new provider:
+1. Create a new folder in [`lib/providers`](https://github.com/hugomd/cloudflare-ddns/tree/master/lib/providers), called `your_provider`
+2. Create a package for your provider in the previously created folder, `your_provider`.
+3. Ensure your provider implements the `Provider` interface
+4. Import your provider in [`lib/providers/_all/all.go`](https://github.com/hugomd/cloudflare-ddns/blob/master/lib/providers/_all/all.go)
+5. Open a PR 🎉
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,50 @@
-# Cloudflare Dynamic DNS
+# Dynamic DNS
 [![](https://images.microbadger.com/badges/image/hugomd/cloudflare-ddns.svg)](https://microbadger.com/images/hugomd/cloudflare-ddns "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/hugomd/cloudflare-ddns.svg)](https://microbadger.com/images/hugomd/cloudflare-ddns "Get your own version badge on microbadger.com") 
 
-> Updates a given Cloudflare DNS record with your current IP
+> Updates a given a DNS record with your current IP
 
+Example with the Cloudflare [provider](#supported-providers):
 ```
 docker run \
-  -e APIKEY=YOUR_API_KEY \
-  -e ZONE=YOUR_ZONE \
-  -e HOST=YOUR_DOMAIN \
-  -e EMAIL=YOUR_CLOUDFLARE_EMAIL \
+  -e PROVIDER=cloudflare \
+  -e CLOUDFLARE_APIKEY=YOUR_API_KEY \
+  -e CLOUDFLARE_ZONE=YOUR_ZONE \
+  -e CLOUDFLARE_HOST=YOUR_DOMAIN \
+  -e CLOUDFLARE_EMAIL=YOUR_CLOUDFLARE_EMAIL \
   hugomd/cloudflare-ddns
 ```
 
+# Supported Providers
+
+| Provider                             | Reference (used for `PROVIDER` environment variable) |
+|--------------------------------------|------------------------------------------------------|
+| [Cloudflare](https://cloudflare.com) | `cloudflare`                                         |
+
+
 # Environment Variables
 
-| Environment Variable | Description                                                                                                             | Example                 | Required |
-|----------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------|----------|
-| `APIKEY`             | [Cloudflare API key](https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-) | `12345`                 | `true`   |
-| `ZONE`               | [Cloudflare Zone](https://api.cloudflare.com/#zone-properties)                                                          | `example.com`           | `true`   |
-| `HOST`               | The record you want to update                                                                                  | `subdomain.example.com` | `true`   |
-| `EMAIL`              | Email associated with your Cloudflare account                                                                           | `john.doe@example.com`  | `true`   |
+All providers require the following environment variable:
+
+| Environment Variable            | Description                             | Example       | Required |
+|---------------------------------|-----------------------------------------|---------------|----------|
+| `PROVIDER`                      | The name of the provider you wish to use | `cloudflare` | `true`   |
+
+## Cloudflare
+
+| Environment Variable            | Description                                                                                                             | Example                 | Required |
+|---------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------|----------|
+| `CLOUDFLARE_APIKEY`             | [Cloudflare API key](https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-) | `12345`                 | `true`   |
+| `CLOUDFLARE_ZONE`               | [Cloudflare Zone](https://api.cloudflare.com/#zone-properties)                                                          | `example.com`           | `true`   |
+| `CLOUDFLARE_HOST`               | The record you want to update                                                                                           | `subdomain.example.com` | `true`   |
+| `CLOUDFLARE_EMAIL`              | Email associated with your Cloudflare account                                                                           | `john.doe@example.com`  | `true`   |
 
 # Contributing
+
 * Fork this repository 🍴
 * Make your changes
 * Open a pull request and ask for review
 * 🎉
 
 # License
+
 MIT, see [LICENSE](./LICENSE).

--- a/lib/providers/_all/all.go
+++ b/lib/providers/_all/all.go
@@ -1,0 +1,5 @@
+package all
+
+import (
+	_ "github.com/hugomd/cloudflare-ddns/lib/providers/cloudflare"
+)

--- a/lib/providers/cloudflare/cloudflare.go
+++ b/lib/providers/cloudflare/cloudflare.go
@@ -1,0 +1,98 @@
+package cloudflare
+
+import (
+	"github.com/hugomd/cloudflare-ddns/lib/providers"
+	"log"
+	"os"
+)
+
+type Cloudflare struct {
+	client *CloudflareAPI
+}
+
+func init() {
+	providers.RegisterProvider("cloudflare", NewProvider)
+}
+
+var ZONE, HOST string
+
+func NewProvider() (providers.Provider, error) {
+	APIKEY := os.Getenv("APIKEY")
+	if APIKEY == "" {
+		log.Fatal("APIKEY env. variable is required")
+	}
+
+	ZONE = os.Getenv("ZONE")
+	if APIKEY == "" {
+		log.Fatal("ZONE env. variable is required")
+	}
+
+	HOST = os.Getenv("HOST")
+	if HOST == "" {
+		log.Fatal("HOST env. variable is required")
+	}
+
+	EMAIL := os.Getenv("EMAIL")
+	if EMAIL == "" {
+		log.Fatal("EMAIL env. variable is required")
+	}
+
+	api, err := NewCloudflareClient(APIKEY, EMAIL, ZONE, HOST)
+	if err != nil {
+		panic(err)
+	}
+
+	provider := &Cloudflare{
+		client: api,
+	}
+
+	return provider, nil
+}
+
+func (api *Cloudflare) UpdateRecord(ip string) error {
+	zones, err := api.client.ListZones()
+	if err != nil {
+		panic(err)
+	}
+
+	var zone Zone
+
+	for i := range zones {
+		if zones[i].Name == ZONE {
+			zone = zones[i]
+		}
+	}
+
+	if zone == (Zone{}) {
+		panic("Zone not found")
+	}
+
+	records, err := api.client.ListDNSRecords(zone)
+	if err != nil {
+		panic(err)
+	}
+
+	var record Record
+	for i := range records {
+		if records[i].Name == HOST {
+			record = records[i]
+		}
+	}
+
+	if record == (Record{}) {
+		panic("Host not found")
+	}
+
+	if ip != record.Content {
+		record.Content = ip
+		err = api.client.UpdateDNSRecord(record, zone)
+		if err != nil {
+			panic(err)
+		}
+		log.Printf("IP changed, updated to %s", ip)
+	} else {
+		log.Print("No change in IP, not updating record")
+	}
+
+	return nil
+}

--- a/lib/providers/providers.go
+++ b/lib/providers/providers.go
@@ -1,0 +1,14 @@
+package providers
+
+type Provider interface {
+	UpdateRecord(ip string) error
+}
+
+type ProviderInit func() (Provider, error)
+
+// Store init function for each provider
+var Providers = map[string]ProviderInit{}
+
+func RegisterProvider(name string, init ProviderInit) {
+	Providers[name] = init
+}


### PR DESCRIPTION
# Breaking Changes in 1.0.0 release
* All environment variables from the previous release (0.1.3) have been prefixed with `CLOUDFLARE`:

| Previously (v0.1.3) | Now (v1.0.0)         |
|---------------------|----------------------|
| `APIKEY`            | `CLOUDFLARE_APIKEY`  |
| `ZONE`              | `CLOUDFLARE_ZONE`    |
| `HOST`              | `CLOUDFLARE_HOST`    |
| `EMAIL`             | `CLOUDFLARE_EMAIL`   |

# Features
* Cloudflare DNS support (still) 🎉 
* Provider support, which means I'll be able to add other providers in the future ✌️ 