### PR TITLE
Support running as a daemon with "-duration" interval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN cd /go/src/github.com/hugomd/cloudflare-ddns && CGO_ENABLED=0 GOOS=linux go 
 FROM scratch
 COPY --from=build-env /go/src/github.com/hugomd/cloudflare-ddns/main /
 COPY --from=build-env /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-CMD ["/main"]
+ENTRYPOINT ["/main"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ docker run \
   hugomd/cloudflare-ddns
 ```
 
+Example running as a persistant daemon:
+```
+docker run -d --restart always \
+  -e PROVIDER=cloudflare \
+  -e CLOUDFLARE_APIKEY=YOUR_API_KEY \
+  -e CLOUDFLARE_ZONE=YOUR_ZONE \
+  -e CLOUDFLARE_HOST=YOUR_DOMAIN \
+  -e CLOUDFLARE_EMAIL=YOUR_CLOUDFLARE_EMAIL \
+  -duration 2h
+```
+
 # Supported Providers
 
 | Provider                             | Reference (used for `PROVIDER` environment variable) |
@@ -36,6 +47,10 @@ All providers require the following environment variable:
 | `CLOUDFLARE_ZONE`               | [Cloudflare Zone](https://api.cloudflare.com/#zone-properties)                                                          | `example.com`           | `true`   |
 | `CLOUDFLARE_HOST`               | The record you want to update                                                                                           | `subdomain.example.com` | `true`   |
 | `CLOUDFLARE_EMAIL`              | Email associated with your Cloudflare account                                                                           | `john.doe@example.com`  | `true`   |
+
+| Parameter             | Description                                                                                                                                                                | Example       | Required |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|
+| `-duration`           | Runs program perpetually and recheck after specified interval; parses time strings such as `5m`, `15m`, `2h30m5s`. If not specified, or if equal to 0s, run once and exit. | 2h            | `false`  |
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker run -d --restart always \
   -e CLOUDFLARE_ZONE=YOUR_ZONE \
   -e CLOUDFLARE_HOST=YOUR_DOMAIN \
   -e CLOUDFLARE_EMAIL=YOUR_CLOUDFLARE_EMAIL \
-  -duration 2h
+  hugomd/cloudflare-ddns -duration 2h
 ```
 
 # Supported Providers

--- a/main.go
+++ b/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"bytes"
+        "flag"
 	"github.com/hugomd/cloudflare-ddns/lib/providers"
 	_ "github.com/hugomd/cloudflare-ddns/lib/providers/_all"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
+	"time"
 )
 
 func checkIP() (string, error) {
@@ -26,6 +28,32 @@ func checkIP() (string, error) {
 }
 
 func main() {
+	var runonce bool
+	var ticker *time.Ticker
+
+	CheckDuration := flag.Duration("duration", 0, "update interval (ex. 15s, 1m, 6h); if not specified or set to 0s, run only once and exit")
+	flag.Parse()
+
+	if *CheckDuration == time.Duration(0) {
+		runonce = true
+	} else {
+		ticker = time.NewTicker(*CheckDuration)
+	}
+
+	runddns()
+
+	if runonce {
+		os.Exit(0)
+	}
+
+	for range ticker.C {
+		runddns()
+	}
+
+	return
+}
+
+func runddns() {
 	PROVIDER := os.Getenv("PROVIDER")
 	if PROVIDER == "" {
 		log.Fatal("PROVIDER env. variable is required")


### PR DESCRIPTION
I added support for my own use case of running as a docker `--restart always` background daemon if `-duration` was specified. I thought I would make an upstream pull request just in case it was useful to you as well. Please feel free to not incorporate if it's not what you had in mind!