### PR TITLE
Load environment variables from a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,27 @@ docker run -d --restart always \
   hugomd/cloudflare-ddns -duration 2h
 ```
 
+You can load environment variables through a config file of key/value pairs.
+
+```sh
+echo "PROVIDER=YOUR_PROVIDER" > config.env
+docker run \
+  -v $PWD/config.env:/tmp/config.env \
+  hugomd/cloudflare-ddns -config /tmp/config.env
+```
+
 # Supported Providers
 
 | Provider                             | Reference (used for `PROVIDER` environment variable) |
 |--------------------------------------|------------------------------------------------------|
 | [Cloudflare](https://cloudflare.com) | `cloudflare`                                         |
+
+# CLI
+
+| Parameter             | Description                                                                                                                                                                | Example           | Required |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|----------|
+| `-duration`           | Runs program perpetually and recheck after specified interval; parses time strings such as `5m`, `15m`, `2h30m5s`. If not specified, or if equal to 0s, run once and exit. | 2h                | `false`  |
+| `-config`             | Loads environment variables from a given file. Variables should be specified as lines of `key=value` pairs. No variables will be loaded if a file is not specified.        | `/tmp/config.env` | `false`  |
 
 # Environment Variables
 
@@ -47,10 +63,6 @@ All providers require the following environment variable:
 | `CLOUDFLARE_ZONE`               | [Cloudflare Zone](https://api.cloudflare.com/#zone-properties)                                                          | `example.com`           | `true`   |
 | `CLOUDFLARE_HOST`               | The record you want to update                                                                                           | `subdomain.example.com` | `true`   |
 | `CLOUDFLARE_EMAIL`              | Email associated with your Cloudflare account                                                                           | `john.doe@example.com`  | `true`   |
-
-| Parameter             | Description                                                                                                                                                                | Example       | Required |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|
-| `-duration`           | Runs program perpetually and recheck after specified interval; parses time strings such as `5m`, `15m`, `2h30m5s`. If not specified, or if equal to 0s, run once and exit. | 2h            | `false`  |
 
 # Contributing
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -27,17 +28,42 @@ func checkIP() (string, error) {
 	return string(bytes.TrimSpace(buf)), nil
 }
 
+func setEnvVarsFromConfig(filename *string) error {
+	contents, err := ioutil.ReadFile(*filename)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(contents), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "=") {
+			values := strings.SplitN(line, "=", 2)
+			os.Setenv(values[0], values[1])
+		}
+	}
+
+	return nil
+}
+
 func main() {
 	var runonce bool
 	var ticker *time.Ticker
 
 	CheckDuration := flag.Duration("duration", 0, "update interval (ex. 15s, 1m, 6h); if not specified or set to 0s, run only once and exit")
+	ConfigFile := flag.String("config", "", "location of an (optional) config file to load environment variables from")
 	flag.Parse()
 
 	if *CheckDuration == time.Duration(0) {
 		runonce = true
 	} else {
 		ticker = time.NewTicker(*CheckDuration)
+	}
+
+	if *ConfigFile != "" {
+		err := setEnvVarsFromConfig(ConfigFile)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	runddns()


### PR DESCRIPTION
Hey!

I've added an optional `-config` flag, which specifies where a list of environment variables can be read from. It assumes each variable comes as a `key=value` pair, and sets them accordingly.

This should close #1, let me know if you think anything more is needed on this!

Happy Hacktoberfest! 🐳 🎃 