### PR TITLE
Change Cloudflare provider to use API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ All providers require the following environment variable:
 | `CLOUDFLARE_EMAIL` **DEPRECATED**  | Email associated with your Cloudflare account                                                                                                              | `john.doe@example.com`  |          |
 | `CLOUDFLARE_APIKEY` **DEPRECATED** | [Cloudflare API key](https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-)                                    | `12345`                 |          |
 
-#### Deprecated Environment Variables
+### Deprecated Environment Variables
 
-Cloudflare now [supports API tokens](https://blog.cloudflare.com/api-tokens-general-availability/) as a more secure way of interacting with their API. Instead of using your global API key/email, you should use a token with limited permissions. When upgrading, you'll need to replace a few existing environment variables.
+Cloudflare now [supports API tokens](https://blog.cloudflare.com/api-tokens-general-availability/) as a more secure way of interacting with their API. Instead of using your global API key/email, you should use a token with limited permissions.
 
-Instead of providing a `CLOUDFLARE_ZONE` with your domain name, you should specify the Zone ID (`CLOUDFLARE_ZONEID`) of your domain name. You can find this in the "Overview" tab for your domain.
+When upgrading, you'll need to replace a few existing environment variables.
+
+Instead of providing a `CLOUDFLARE_ZONE` with your domain name, you should specify the Zone ID (`CLOUDFLARE_ZONEID`) of your domain. You can find this in the "Overview" tab for your domain.
 
 Instead of your `CLOUDFLARE_EMAIL` and `CLOUDFLARE_APIKEY`, you should [generate a token](https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys#12345680) (`CLOUDFLARE_APITOKEN`) with permission to edit DNS records for your desired zone.
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ Example with the Cloudflare [provider](#supported-providers):
 ```
 docker run \
   -e PROVIDER=cloudflare \
-  -e CLOUDFLARE_APIKEY=YOUR_API_KEY \
-  -e CLOUDFLARE_ZONE=YOUR_ZONE \
+  -e CLOUDFLARE_APITOKEN=YOUR_API_TOKEN \
+  -e CLOUDFLARE_ZONEID=YOUR_ZONE_ID \
   -e CLOUDFLARE_HOST=YOUR_DOMAIN \
-  -e CLOUDFLARE_EMAIL=YOUR_CLOUDFLARE_EMAIL \
   hugomd/cloudflare-ddns
 ```
 
@@ -18,10 +17,9 @@ Example running as a persistant daemon:
 ```
 docker run -d --restart always \
   -e PROVIDER=cloudflare \
-  -e CLOUDFLARE_APIKEY=YOUR_API_KEY \
-  -e CLOUDFLARE_ZONE=YOUR_ZONE \
+  -e CLOUDFLARE_APITOKEN=YOUR_API_TOKEN \
+  -e CLOUDFLARE_ZONEID=YOUR_ZONE_ID \
   -e CLOUDFLARE_HOST=YOUR_DOMAIN \
-  -e CLOUDFLARE_EMAIL=YOUR_CLOUDFLARE_EMAIL \
   hugomd/cloudflare-ddns -duration 2h
 ```
 
@@ -57,12 +55,24 @@ All providers require the following environment variable:
 
 ## Cloudflare
 
-| Environment Variable            | Description                                                                                                             | Example                 | Required |
-|---------------------------------|-------------------------------------------------------------------------------------------------------------------------|-------------------------|----------|
-| `CLOUDFLARE_APIKEY`             | [Cloudflare API key](https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-) | `12345`                 | `true`   |
-| `CLOUDFLARE_ZONE`               | [Cloudflare Zone](https://api.cloudflare.com/#zone-properties)                                                          | `example.com`           | `true`   |
-| `CLOUDFLARE_HOST`               | The record you want to update                                                                                           | `subdomain.example.com` | `true`   |
-| `CLOUDFLARE_EMAIL`              | Email associated with your Cloudflare account                                                                           | `john.doe@example.com`  | `true`   |
+| Environment Variable               | Description                                                                                                                                                | Example                 | Required |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------- |
+| `CLOUDFLARE_APITOKEN`              | An [API Token](https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys), with permission to edit DNS records for your zone | `12345`                 | `true`   |
+| `CLOUDFLARE_ZONEID`                | The Zone ID of your domain in Cloudflare (you can find this in the "Overview" tab at the bottom of the page)                                               | `dd255baaaaad2e8...`    | `true`   |
+| `CLOUDFLARE_HOST`                  | The record you want to update                                                                                                                              | `subdomain.example.com` | `true`   |
+| `CLOUDFLARE_ZONE` **DEPRECATED**   | [Cloudflare Zone](https://api.cloudflare.com/#zone-properties)                                                                                             | `example.com`           |          |
+| `CLOUDFLARE_EMAIL` **DEPRECATED**  | Email associated with your Cloudflare account                                                                                                              | `john.doe@example.com`  |          |
+| `CLOUDFLARE_APIKEY` **DEPRECATED** | [Cloudflare API key](https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-)                                    | `12345`                 |          |
+
+#### Deprecated Environment Variables
+
+Cloudflare now [supports API tokens](https://blog.cloudflare.com/api-tokens-general-availability/) as a more secure way of interacting with their API. Instead of using your global API key/email, you should use a token with limited permissions. When upgrading, you'll need to replace a few existing environment variables.
+
+Instead of providing a `CLOUDFLARE_ZONE` with your domain name, you should specify the Zone ID (`CLOUDFLARE_ZONEID`) of your domain name. You can find this in the "Overview" tab for your domain.
+
+Instead of your `CLOUDFLARE_EMAIL` and `CLOUDFLARE_APIKEY`, you should [generate a token](https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys#12345680) (`CLOUDFLARE_APITOKEN`) with permission to edit DNS records for your desired zone.
+
+You don't need to make any changes to your `CLOUDFLARE_HOST`.
 
 # Contributing
 

--- a/lib/providers/cloudflare/api.go
+++ b/lib/providers/cloudflare/api.go
@@ -70,7 +70,7 @@ func (api *CloudflareAPI) ListZones() ([]Zone, error) {
 }
 
 func (api *CloudflareAPI) ListDNSRecords(zone Zone) ([]Record, error) {
-	uri := fmt.Sprintf("/zones/%s/dns_records?name=%s", zone.ID, api.Host)
+	uri := fmt.Sprintf("/zones/%s/dns_records?type=A&name=%s", zone.ID, api.Host)
 	resp, err := api.request("GET", uri, nil)
 	if err != nil {
 		return nil, err

--- a/lib/providers/cloudflare/api.go
+++ b/lib/providers/cloudflare/api.go
@@ -10,10 +10,9 @@ import (
 )
 
 type CloudflareAPI struct {
-	ZoneID       string
+	ZoneID     string
 	Host       string
-	APIKey     string
-	Email      string
+	APIToken   string
 	BaseURL    string
 	httpClient *http.Client
 }
@@ -30,13 +29,12 @@ type RecordResponse struct {
 	Result []Record `json:"result"`
 }
 
-func NewCloudflareClient(key string, email string, zoneID string, host string) (*CloudflareAPI, error) {
+func NewCloudflareClient(token string, zoneID string, host string) (*CloudflareAPI, error) {
 	api := CloudflareAPI{
-		ZoneID:    zoneID,
-		Host:    host,
-		APIKey:  key,
-		Email:   email,
-		BaseURL: "https://api.cloudflare.com/client/v4",
+		ZoneID:   zoneID,
+		Host:     host,
+		APIToken: token,
+		BaseURL:  "https://api.cloudflare.com/client/v4",
 	}
 
 	if api.httpClient == nil {
@@ -83,8 +81,7 @@ func (api *CloudflareAPI) request(method string, uri string, body io.Reader) ([]
 		return nil, err
 	}
 
-	req.Header.Set("X-Auth-Email", api.Email)
-	req.Header.Set("X-Auth-Key", api.APIKey)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", api.APIToken))
 
 	resp, err := api.httpClient.Do(req)
 	if err != nil {

--- a/lib/providers/cloudflare/api.go
+++ b/lib/providers/cloudflare/api.go
@@ -10,21 +10,12 @@ import (
 )
 
 type CloudflareAPI struct {
-	Zone       string
+	ZoneID       string
 	Host       string
 	APIKey     string
 	Email      string
 	BaseURL    string
 	httpClient *http.Client
-}
-
-type Zone struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-}
-
-type ZoneResponse struct {
-	Result []Zone `json:"result"`
 }
 
 type Record struct {
@@ -39,9 +30,9 @@ type RecordResponse struct {
 	Result []Record `json:"result"`
 }
 
-func NewCloudflareClient(key string, email string, zone string, host string) (*CloudflareAPI, error) {
+func NewCloudflareClient(key string, email string, zoneID string, host string) (*CloudflareAPI, error) {
 	api := CloudflareAPI{
-		Zone:    zone,
+		ZoneID:    zoneID,
 		Host:    host,
 		APIKey:  key,
 		Email:   email,
@@ -55,23 +46,8 @@ func NewCloudflareClient(key string, email string, zone string, host string) (*C
 	return &api, nil
 }
 
-func (api *CloudflareAPI) ListZones() ([]Zone, error) {
-	uri := fmt.Sprintf("/zones?name=%s", api.Zone)
-	resp, err := api.request("GET", uri, nil)
-	if err != nil {
-		return nil, err
-	}
-	var r ZoneResponse
-	err = json.Unmarshal(resp, &r)
-
-	if err != nil {
-		return nil, err
-	}
-	return r.Result, nil
-}
-
-func (api *CloudflareAPI) ListDNSRecords(zone Zone) ([]Record, error) {
-	uri := fmt.Sprintf("/zones/%s/dns_records?type=A&name=%s", zone.ID, api.Host)
+func (api *CloudflareAPI) ListDNSRecords() ([]Record, error) {
+	uri := fmt.Sprintf("/zones/%s/dns_records?type=A&name=%s", api.ZoneID, api.Host)
 	resp, err := api.request("GET", uri, nil)
 	if err != nil {
 		return nil, err
@@ -87,8 +63,8 @@ func (api *CloudflareAPI) ListDNSRecords(zone Zone) ([]Record, error) {
 	return r.Result, nil
 }
 
-func (api *CloudflareAPI) UpdateDNSRecord(record Record, zone Zone) error {
-	uri := fmt.Sprintf("/zones/%s/dns_records/%s", zone.ID, record.ID)
+func (api *CloudflareAPI) UpdateDNSRecord(record Record) error {
+	uri := fmt.Sprintf("/zones/%s/dns_records/%s", api.ZoneID, record.ID)
 
 	payload := new(bytes.Buffer)
 	json.NewEncoder(payload).Encode(record)

--- a/lib/providers/cloudflare/api.go
+++ b/lib/providers/cloudflare/api.go
@@ -32,6 +32,7 @@ type Record struct {
 	Type    string `json:"type"`
 	Content string `json:"content"`
 	Name    string `json:"name"`
+	Proxied bool   `json:"proxied"`
 }
 
 type RecordResponse struct {

--- a/lib/providers/cloudflare/cloudflare.go
+++ b/lib/providers/cloudflare/cloudflare.go
@@ -18,6 +18,17 @@ func init() {
 var ZONEID, HOST string
 
 func NewProvider() (providers.Provider, error) {
+	// Check for use of any deprecated variables first, point to how to update
+	if os.Getenv("CLOUDFLARE_APIKEY") != "" {
+		log.Fatal("Do not use CLOUDFLARE_APIKEY, see https://github.com/hugomd/cloudflare-ddns#deprecated-environment-variables")
+	}
+	if os.Getenv("CLOUDFLARE_EMAIL") != "" {
+		log.Fatal("Do not use CLOUDFLARE_EMAIL, see https://github.com/hugomd/cloudflare-ddns#deprecated-environment-variables")
+	}
+	if os.Getenv("CLOUDFLARE_ZONE") != "" {
+		log.Fatal("Do not use CLOUDFLARE_ZONE, see https://github.com/hugomd/cloudflare-ddns#deprecated-environment-variables")
+	}
+
 	APITOKEN := os.Getenv("CLOUDFLARE_APITOKEN")
 	if APITOKEN == "" {
 		log.Fatal("CLOUDFLARE_APITOKEN env. variable is required")

--- a/lib/providers/cloudflare/cloudflare.go
+++ b/lib/providers/cloudflare/cloudflare.go
@@ -15,7 +15,7 @@ func init() {
 	providers.RegisterProvider("cloudflare", NewProvider)
 }
 
-var ZONE, HOST string
+var ZONEID, HOST string
 
 func NewProvider() (providers.Provider, error) {
 	APIKEY := os.Getenv("CLOUDFLARE_APIKEY")
@@ -23,9 +23,9 @@ func NewProvider() (providers.Provider, error) {
 		log.Fatal("CLOUDFLARE_APIKEY env. variable is required")
 	}
 
-	ZONE = os.Getenv("CLOUDFLARE_ZONE")
-	if APIKEY == "" {
-		log.Fatal("CLOUDFLARE_ZONE env. variable is required")
+	ZONEID = os.Getenv("CLOUDFLARE_ZONEID")
+	if ZONEID == "" {
+		log.Fatal("CLOUDFLARE_ZONEID env. variable is required")
 	}
 
 	HOST = os.Getenv("CLOUDFLARE_HOST")
@@ -38,7 +38,7 @@ func NewProvider() (providers.Provider, error) {
 		log.Fatal("CLOUDFLARE_EMAIL env. variable is required")
 	}
 
-	api, err := NewCloudflareClient(APIKEY, EMAIL, ZONE, HOST)
+	api, err := NewCloudflareClient(APIKEY, EMAIL, ZONEID, HOST)
 	if err != nil {
 		return nil, err
 	}
@@ -51,24 +51,7 @@ func NewProvider() (providers.Provider, error) {
 }
 
 func (api *Cloudflare) UpdateRecord(ip string) error {
-	zones, err := api.client.ListZones()
-	if err != nil {
-		return err
-	}
-
-	var zone Zone
-
-	for i := range zones {
-		if zones[i].Name == ZONE {
-			zone = zones[i]
-		}
-	}
-
-	if zone == (Zone{}) {
-		return errors.New("Zone not found")
-	}
-
-	records, err := api.client.ListDNSRecords(zone)
+	records, err := api.client.ListDNSRecords()
 	if err != nil {
 		return err
 	}
@@ -86,7 +69,7 @@ func (api *Cloudflare) UpdateRecord(ip string) error {
 
 	if ip != record.Content {
 		record.Content = ip
-		err = api.client.UpdateDNSRecord(record, zone)
+		err = api.client.UpdateDNSRecord(record)
 		if err != nil {
 			return err
 		}

--- a/lib/providers/cloudflare/cloudflare.go
+++ b/lib/providers/cloudflare/cloudflare.go
@@ -18,9 +18,9 @@ func init() {
 var ZONEID, HOST string
 
 func NewProvider() (providers.Provider, error) {
-	APIKEY := os.Getenv("CLOUDFLARE_APIKEY")
-	if APIKEY == "" {
-		log.Fatal("CLOUDFLARE_APIKEY env. variable is required")
+	APITOKEN := os.Getenv("CLOUDFLARE_APITOKEN")
+	if APITOKEN == "" {
+		log.Fatal("CLOUDFLARE_APITOKEN env. variable is required")
 	}
 
 	ZONEID = os.Getenv("CLOUDFLARE_ZONEID")
@@ -33,12 +33,7 @@ func NewProvider() (providers.Provider, error) {
 		log.Fatal("CLOUDFLARE_HOST env. variable is required")
 	}
 
-	EMAIL := os.Getenv("CLOUDFLARE_EMAIL")
-	if EMAIL == "" {
-		log.Fatal("CLOUDFLARE_EMAIL env. variable is required")
-	}
-
-	api, err := NewCloudflareClient(APIKEY, EMAIL, ZONEID, HOST)
+	api, err := NewCloudflareClient(APITOKEN, ZONEID, HOST)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hey Hugo!

I've changed some of the workings for the Cloudflare provider to use an API token instead of a user's API key and email. Tokens were [introduced last year](https://blog.cloudflare.com/api-tokens-general-availability/) as a more secure approach to the original global API key.

There's a few changes that come with this PR, so I've tried to summarise them below.

### Require zone ID instead a domain name
Having the zone ID provided by the user removes the need to look up an account's zones, searching for the corresponding domain name and zone ID.

This means the only API calls we need to make are zone-related (read/update DNS records), which lends itself well to using API tokens.

Copying over the zone ID is a bit unwieldy, but it should only be a one-time change for users.

### Use API tokens over API keys
Tokens can be scoped to only have access to individual zones, and can have granular permissions.

All a token should need is permission to edit DNS records for the target zone.

### QOL changes
I've also added a few changes for problems I encountered while running this on my own system.

* Hosts will maintain their existing proxy status (orange-clouded) instead of defaulting to `false` when updating records
* Only `A` records will be requested - this should avoid accidentally overwriting other records (`MX`/`TXT`) for a host

### Backwards compatability
These changes mean a release with breaking changes. To upgrade, users will need to update their config/environment variables.
* `CLOUDFLARE_ZONE` -> `CLOUDFLARE_ZONEID`
* `CLOUDFLARE_EMAIL`/`CLOUDFLARE_APIKEY` -> `CLOUDFLARE_APITOKEN`

If any of these old environment variables are used, I figured failing with a warning would be the best option.

```sh
CLOUDFLARE_ZONE=nicholas.cloud ./cloudflare-ddns -config nicholas.cloud.env
# 2020/05/08 21:14:04 Do not use CLOUDFLARE_ZONE, see https://github.com/hugomd/cloudflare-ddns#deprecated-environment-variables
```

This breaking change could be avoided by copying all of these files into a new provider (`cloudflare-with-api-token`?), though that would mean maintaining two Cloudflare providers.

Apologies for the wall of text, I know there's a bit to this PR.
